### PR TITLE
Update .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
 	"description": "This repository contains the scripts for a simulation study performed on data from the systematic review by Brouwer et al. (2019). The goal was to obtain the Time to Discovery (TD) for each relevant paper. The simulation study has the following characteristics: The number of runs is equal to the number of inclusions in the dataset; Every run starts with 1 prior inclusion and 10 prior exclusions; The prior inclusion is different for every run, e.g. all inclusions in the data are used as a prior inclusion once; The 10 prior exclusions are the same for every run, and they are randomly sampled from the dataset. The output is a file with all inclusions ordered by their Time to Discovery.",
-	"title": "Scripts and Ouptut for the Simulation Study Determining the Time to Discovery for the Depression Data",
+	"title": "Scripts and Output for the Simulation Study Determining the Time to Discovery for the Depression Data",
 	"creators": [{
 			"name": "Ferdinands, Gerbrich",
 			"affiliation": "Department of Methodology and Statistics, Faculty of Social and Behavioral Sciences, Utrecht University, Utrecht, the Netherlands",


### PR DESCRIPTION
There is a typo in the title of the Zenodo release, this PR will adjust this. It will require a new GitHub release.